### PR TITLE
[FIX] Xpath fix

### DIFF
--- a/account_cost_spread/views/account_config_settings.xml
+++ b/account_cost_spread/views/account_config_settings.xml
@@ -7,7 +7,7 @@
             <field name="inherit_id" ref="account.view_account_config_settings"/>
             <field name="model">account.config.settings</field>
             <field name="arch" type="xml">
-                <xpath expr="//field[@name='module_account_asset']/.." position="after">
+                <xpath expr="//field[starts-with(@name, 'module_account_asset')]/.." position="after">
                     <div>
                         <field name="module_account_cost_spread" class="oe_inline"/>
                         <label for="module_account_cost_spread"/>


### PR DESCRIPTION
Flexible xpath to ensure compatibility with OCA account_asset_management.

account_asset_management replaces the original field and adds a different one breaking the xpath.

By using this xpath instead compatibility with stock and OCA is kept

@astirpe can you take a look?