### PR TITLE
Update account_invoice_spread_line.py

### DIFF
--- a/account_cost_spread/models/account_invoice_spread_line.py
+++ b/account_cost_spread/models/account_invoice_spread_line.py
@@ -50,7 +50,7 @@ class AccountInvoiceSpreadLine(models.Model):
          ],
         string='Type',
         readonly=True,
-        defaults='depreciate')
+        default='depreciate')
     init_entry = fields.Boolean(
         string='Initial Balance Entry',
         help="Set this flag for entries of previous fiscal years "


### PR DESCRIPTION
setting column type default value to depreciate does not work 
should be default instead of defaults