### PR TITLE
[ADD] don't try to execute spreads on cancelled invoices or closed periods

### DIFF
--- a/account_cost_spread/models/account_invoice_spread_line.py
+++ b/account_cost_spread/models/account_invoice_spread_line.py
@@ -263,6 +263,8 @@ class AccountInvoiceSpreadLine(models.Model):
         lines = self.search([
             ('line_date', '<=', period.date_stop),
             ('invoice_line_id.spread_account_id', '!=', False),
+            ('invoice_line_id.invoice_id.state', '!=', 'cancel'),
+            ('invoice_line_id.invoice_id.period_id.state', '!=', 'done'),
             ('move_id', '=', False),
         ])
 


### PR DESCRIPTION
for the first I considered to clean up spreads when cancelling an invoice, but this will make the user unhappy if the invoice is to be uncancelled again. The second is the result of the cronjob not running for a while.