### PR TITLE
Filter unsupported 'show as' options for events

### DIFF
--- a/connector_office_365/models/calendar_event.py
+++ b/connector_office_365/models/calendar_event.py
@@ -28,13 +28,18 @@ class CalendarEvent(models.Model):
         if event['isAllDay']:
             stop -= timedelta(days=1)
 
+        show_as_options = [sel[0] for sel in self._fields['show_as'].selection]
+        show_as = (
+            event['showAs'] if event['showAs'] in show_as_options else 'busy'
+        )
+
         return {
             'name': event['subject'],
             'privacy': 'private',
             'state': 'open',
             'allday': event['isAllDay'],
             'user_id': event['isOrganizer'] and user.id,
-            'show_as': event['showAs'],
+            'show_as': show_as,
             'office_365_url': event['webLink'],
             'office_365_id': event['id'],
             'office_365_series_id': event.get('seriesMasterId', False),


### PR DESCRIPTION
Office 365 events shown as provisory, travel, away, ... make the fetch
of event fail because no matching option exists in Odoo.

Consider the existing options and if they don't match, use 'busy'.
So it prevent the failure while still allowing users to add the new
selection options in 'show_as'.