### PR TITLE
Add methods to push events to office365

### DIFF
--- a/connector_office_365/README.rst
+++ b/connector_office_365/README.rst
@@ -79,3 +79,4 @@ Contributors
 ~~~~~~~~~~~~
 
 * Dennis Sluijk <d.sluijk@onestein.nl>
+* Guewen Baconnier <guewen.baconnier@camptocamp.com>

--- a/connector_office_365/models/res_users.py
+++ b/connector_office_365/models/res_users.py
@@ -148,6 +148,12 @@ class ResUsers(models.Model):
     def office_365_request(self, method, url, data=None, headers=None):
         self.ensure_one()
 
+        if not self.office_365_access_token:
+            raise exceptions.UserError(
+                _('User "{}" not authenticated with Office 365')
+                .format(self.login)
+            )
+
         config = self.env['ir.config_parameter'].sudo()
         client_id = config.get_param('office_365.client_id')
         client_secret = config.get_param('office_365.client_secret')

--- a/connector_office_365/models/res_users.py
+++ b/connector_office_365/models/res_users.py
@@ -169,7 +169,7 @@ class ResUsers(models.Model):
                                    data=data,
                                    client_id=client_id,
                                    client_secret=client_secret)
-        if response.status_code not in [200, 204]:
+        if not response.ok:
             error = json.loads(response.text)
             raise Exception(error['error']['message'])
         return response


### PR DESCRIPTION
# Add methods to push events to office365

So we can reuse them from other addons. I'll open another pull request to add
push of HR leaves.

# Use .ok property to validate o365's response

Codes 200 and 204 are not enough, for instance, after a POST, it answers
201.

# Add support of all day events

The all day events behaves weirdly on o365. When created from the API, it
is really picky on the values we pass, otherwise it ends up displaying an
extra day on the calendar. We must have a timezone that matches the one
used by the user on o365 (I assume, or it does not like UTC...).