### PR TITLE
[FIX] reconciliation reconciles wrong things with same account

### DIFF
--- a/account_cost_spread/models/account_invoice_spread_line.py
+++ b/account_cost_spread/models/account_invoice_spread_line.py
@@ -208,11 +208,12 @@ class AccountInvoiceSpreadLine(models.Model):
 
             # reconcile if possible
             if invoice_line.spread_account_id.reconcile:
+                reconcile_move_line = invoice_line.invoice_id.type in (
+                    'in_invoice', 'out_refund'
+                ) and debit_move_line or credit_move_line
                 (
-                    debit_move_line + credit_move_line +
+                    reconcile_move_line +
                     invoice_line._find_move_line()
-                ).filtered(
-                    lambda x: x.account_id == invoice_line.spread_account_id
                 ).reconcile_partial()
             created_move_ids.append(move_id.id)
         return created_move_ids


### PR DESCRIPTION
when we spread over the same account, we'll get a partial reconciliation with all lines, which we don't want to have. What we want is to reconcile the invoice line's move line with one of the credit/debit move lines depending of the type of invoice.

The changes in the test are because they're wrong: They test the wrong thing, and only work because the USD currency on a EUR company will cause `_find_move_line` to find nothing (credit/debit is in EUR), which has caused a full reconciliation on the credit+debit move lines.