### PR TITLE
Add tenant ID for single tenant application

### DIFF
--- a/connector_office_365/models/res_config_settings.py
+++ b/connector_office_365/models/res_config_settings.py
@@ -9,12 +9,15 @@ class ResConfigSettings(models.TransientModel):
 
     office_365_client_id = fields.Char(string='Client ID')
     office_365_client_secret = fields.Char(string='Client Secret')
+    office_365_tenant_id = fields.Char(string='Tenant ID', default='common',
+        help='Place here Tenant ID (or Application ID), if multi-tenant application, use "common" instead')
 
     @api.model
     def get_values(self):
         res = super().get_values()
         get_param = self.env['ir.config_parameter'].sudo().get_param
         res.update({
+            'office_365_tenant_id': get_param('office_365.tenant_id'),
             'office_365_client_id': get_param('office_365.client_id'),
             'office_365_client_secret': get_param('office_365.client_secret'),
         })
@@ -24,5 +27,6 @@ class ResConfigSettings(models.TransientModel):
     def set_values(self):
         super().set_values()
         set_param = self.env['ir.config_parameter'].sudo().set_param
+        set_param('office_365.tenant_id', self.office_365_tenant_id)
         set_param('office_365.client_id', self.office_365_client_id)
         set_param('office_365.client_secret', self.office_365_client_secret)

--- a/connector_office_365/models/res_users.py
+++ b/connector_office_365/models/res_users.py
@@ -13,9 +13,9 @@ try:
 except ImportError:
     logger.debug('Cannot import requests_oauthlib')
 
-
-AUTH_URL = 'https://login.microsoftonline.com/common/oauth2/v2.0/authorize'
-TOKEN_URL = 'https://login.microsoftonline.com/common/oauth2/v2.0/token'
+BASE_URL = 'https://login.microsoftonline.com/'
+AUTH_URI = '/oauth2/v2.0/authorize'
+TOKEN_URI = '/oauth2/v2.0/token'
 API_BASE_URL = 'https://graph.microsoft.com/v1.0'
 
 
@@ -93,18 +93,21 @@ class ResUsers(models.Model):
     @api.model
     def office_365_authorization_url(self, scope=None):
         session = self._office_365_get_session(scope=scope)
+        config = self.env['ir.config_parameter'].sudo()
+        tenant_id = config.get_param('office_365.tenant_id')
         return session.authorization_url(
-            url=AUTH_URL
+            url=BASE_URL + tenant_id + AUTH_URI
         )
 
     @api.model
     def office_365_get_token(self, authorization_response):
         config = self.env['ir.config_parameter'].sudo()
         client_secret = config.get_param('office_365.client_secret')
+        tenant_id = config.get_param('office_365.tenant_id')
 
         session = self._office_365_get_session()
         return session.fetch_token(
-            token_url=TOKEN_URL,
+            token_url=BASE_URL + tenant_id + TOKEN_URI,
             authorization_response=authorization_response,
             include_client_id=True,
             client_secret=client_secret
@@ -132,11 +135,12 @@ class ResUsers(models.Model):
             session = self._office_365_get_session()
 
             config = self.env['ir.config_parameter'].sudo()
+            tenant_id = config.get_param('office_365.tenant_id')
             client_id = config.get_param('office_365.client_id')
             client_secret = config.get_param('office_365.client_secret')
 
             token = session.refresh_token(
-                token_url=TOKEN_URL,
+                token_url=BASE_URL + tenant_id + TOKEN_URI,
                 client_id=client_id,
                 client_secret=client_secret,
                 refresh_token=self.office_365_refresh_token

--- a/connector_office_365/views/res_config_settings_view.xml
+++ b/connector_office_365/views/res_config_settings_view.xml
@@ -14,6 +14,10 @@
                     <div class="o_setting_right_pane" name="critical_path_duration_base_right_pane">
                         <label for="office_365_client_id" string="Office 365"/>
                         <div class="text-muted">
+                            Tenant ID
+                        </div>
+                        <field name="office_365_tenant_id" class="o_light_label"/>
+                        <div class="text-muted">
                             Client ID
                         </div>
                         <field name="office_365_client_id" class="o_light_label"/>


### PR DESCRIPTION
The module has it is designed today only works for multi-tenant Office 365 configuration.
In case a single-tenant application is defined, the URL needs include the tenant ID instead of common.
This PR adds a field to store tenant id and recalculate URL depending on this tenant id (default remaining common in order not to create regression).