### PR TITLE
[12.0] Fix issues with connector_office_365 and hr.leaves

### DIFF
--- a/connector_office_365/models/calendar_event.py
+++ b/connector_office_365/models/calendar_event.py
@@ -153,10 +153,14 @@ class CalendarEvent(models.Model):
                 record._office_365_push_create()
             else:
                 if record.user_id.id != self.env.user.id:
+                    _logger.error(
+                        'office_365_push: attempt by user %s to push '
+                        'record %s owned by user %s',
+                        self.env.user, record, record.user_id)
                     raise exceptions.UserError(
-                        _('You are not the organizer of the event "{}"'
+                        _('You are not the organizer of the event "{}" ({})'
                           ' please try to edit this event in Office 365.')
-                        .format(record.name)
+                        .format(record.name, record.user_id.name)
                     )
                 record._office_365_push_update()
 
@@ -239,9 +243,14 @@ class CalendarEvent(models.Model):
         for event in self:
             if event.office_365_id and not self.env.context.get('office_365_force', False):
                 if event.user_id.id != user.id:
+                    _logger.error(
+                        'calendar event unlink: attempt by user %s to unlink '
+                        'record %s owned by user %s',
+                        self.env.user, event, event.user_id)
                     raise exceptions.UserError(
-                        _('You are not the organizer of this '
-                          'event please try delete this event in Office 365.')
+                        _('You are not the organizer of the '
+                          'event {} ({}) please try delete this event in Office 365.').format(
+                              event.name, event.user_id.name)
                     )
                 try:
                     user.office_365_delete(

--- a/connector_office_365/models/res_users.py
+++ b/connector_office_365/models/res_users.py
@@ -102,7 +102,7 @@ class ResUsers(models.Model):
     def office_365_authorization_url(self, scope=None):
         session = self._office_365_get_session(scope=scope)
         config = self.env['ir.config_parameter'].sudo()
-        tenant_id = config.get_param('office_365.tenant_id')
+        tenant_id = config.get_param('office_365.tenant_id') or 'common'
         return session.authorization_url(
             url=BASE_URL + tenant_id + AUTH_URI
         )
@@ -111,7 +111,7 @@ class ResUsers(models.Model):
     def office_365_get_token(self, authorization_response):
         config = self.env['ir.config_parameter'].sudo()
         client_secret = config.get_param('office_365.client_secret')
-        tenant_id = config.get_param('office_365.tenant_id')
+        tenant_id = config.get_param('office_365.tenant_id') or 'common'
 
         session = self._office_365_get_session()
         return session.fetch_token(
@@ -143,7 +143,7 @@ class ResUsers(models.Model):
             session = self._office_365_get_session()
 
             config = self.env['ir.config_parameter'].sudo()
-            tenant_id = config.get_param('office_365.tenant_id')
+            tenant_id = config.get_param('office_365.tenant_id') or 'common'
             client_id = config.get_param('office_365.client_id')
             client_secret = config.get_param('office_365.client_secret')
 

--- a/connector_office_365_hr_leave/models/hr_leave.py
+++ b/connector_office_365_hr_leave/models/hr_leave.py
@@ -46,9 +46,9 @@ class HolidaysRequest(models.Model):
             self.activity_schedule(xmlid, user_id=self.user_id.id)
 
     def _validate_leave_request(self):
-        super()._validate_leave_request()
+        super(HolidaysRequest, self.with_context(office_365_force=True))._validate_leave_request()
         for leave in self:
-            if not leave.meeting_id and leave.meeting_id.user_id:
+            if not (leave.meeting_id and leave.meeting_id.user_id):
                 continue
             leave._office_365_push()
 


### PR DESCRIPTION
The details are in each commit

* fix a crash when migrating from a version where tenant_id is not present
* fix a crash when validating a Leave request when the employee is not authenticated in office 365
* improve some error messages and logging
