### PR TITLE
[FIX] [8.0] account_budgetary_unit_period

### DIFF
--- a/account_budgetary_position_period/models/crossovered_budget_lines.py
+++ b/account_budgetary_position_period/models/crossovered_budget_lines.py
@@ -3,6 +3,8 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 from openerp import models, fields, api, _
+from openerp.osv import osv
+from openerp.tools import ustr
 
 
 class CrossoveredBudgetLines(models.Model):
@@ -44,6 +46,70 @@ class CrossoveredBudgetLines(models.Model):
         for line in self:
             if line.period_stop:
                 line.date_to = line.period_stop.date_stop
+
+    def _prac_amt(self, cr, uid, ids, context=None):
+        res = super(CrossoveredBudgetLines, self)._prac_amt(
+            cr, uid, ids, context=context)
+        if context is None:
+            context = {}
+        account_obj = self.pool.get('account.account')
+        for line in self.browse(cr, uid, ids, context=context):
+            result = 0.0
+            acc_ids = [x.id for x in line.general_budget_id.account_ids]
+            if not acc_ids:
+                raise osv.except_osv(
+                    _('Error!'),
+                    _("The Budget '%s' has no accounts!") % ustr(
+                        line.general_budget_id.name))
+            acc_ids = account_obj._get_children_and_consol(
+                cr, uid, acc_ids, context=context)
+            date_from = line.period_start.date_start
+            date_to = line.period_stop.date_stop
+            if line.analytic_account_id.id:
+                # lines without move_id.period_id: match on date
+                cr.execute("""
+                SELECT SUM(aal.amount)
+                FROM account_analytic_line aal
+                LEFT JOIN account_move_line aml
+                    ON aml.id = aal.move_id
+                WHERE aal.account_id=%s
+                AND aal.date BETWEEN to_date(%s,'yyyy-mm-dd')
+                    AND to_date(%s,'yyyy-mm-dd')
+                AND aal.general_account_id=ANY(%s)
+                AND aml.period_id is null
+                """, (
+                    line.analytic_account_id.id,
+                    date_from,
+                    date_to,
+                    acc_ids
+                ))
+                result += cr.fetchone()[0] or 0.00
+
+                # lines with move_id.period_id: match on period
+                cr.execute("""
+                SELECT SUM(aal.amount)
+                FROM account_analytic_line aal
+                INNER JOIN account_move_line aml
+                    ON aml.id = aal.move_id
+                INNER JOIN account_period ap
+                    ON ap.id = aml.period_id
+                WHERE aal.account_id=%s
+                AND ap.id in (
+                    SELECT id
+                    from account_period
+                    where date_start BETWEEN to_date(%s,'yyyy-mm-dd')
+                        AND to_date(%s,'yyyy-mm-dd')
+                )
+                AND aal.general_account_id=ANY(%s)
+                """, (
+                    line.analytic_account_id.id,
+                    date_from,
+                    date_to,
+                    acc_ids
+                ))
+                result += cr.fetchone()[0] or 0.00
+            res[line.id] = result
+        return res
 
     @api.model
     def create(self, vals):


### PR DESCRIPTION
On calculating a budget; if an analytic line has a related move line, add its amount to the total of the move line period and not the analytic line date.