### PR TITLE
[FIX] account_budgetary_unit_period _prac_amt

### DIFF
--- a/account_budgetary_position_period/models/crossovered_budget_lines.py
+++ b/account_budgetary_position_period/models/crossovered_budget_lines.py
@@ -72,7 +72,20 @@ class CrossoveredBudgetLines(models.Model):
                 FROM account_analytic_line aal
                 LEFT JOIN account_move_line aml
                     ON aml.id = aal.move_id
-                WHERE aal.account_id=%s
+                WHERE aal.account_id in (
+                    -- from: https://github.com/odoo/odoo/pull/6910/files
+                    with recursive account_analytic_account_hierarchy(id) as (
+                        select id from account_analytic_account
+                            where id=%s
+                        union all
+                        select account_analytic_account.id
+                        from account_analytic_account
+                        join account_analytic_account_hierarchy
+                        on account_analytic_account.parent_id=
+                            account_analytic_account_hierarchy.id
+                    )
+                    select id from account_analytic_account_hierarchy
+                )
                 AND aal.date BETWEEN to_date(%s,'yyyy-mm-dd')
                     AND to_date(%s,'yyyy-mm-dd')
                 AND aal.general_account_id=ANY(%s)
@@ -93,7 +106,20 @@ class CrossoveredBudgetLines(models.Model):
                     ON aml.id = aal.move_id
                 INNER JOIN account_period ap
                     ON ap.id = aml.period_id
-                WHERE aal.account_id=%s
+                WHERE aal.account_id in (
+                    -- from: https://github.com/odoo/odoo/pull/6910/files
+                    with recursive account_analytic_account_hierarchy(id) as (
+                        select id from account_analytic_account
+                            where id=%s
+                        union all
+                        select account_analytic_account.id
+                        from account_analytic_account
+                        join account_analytic_account_hierarchy
+                        on account_analytic_account.parent_id=
+                            account_analytic_account_hierarchy.id
+                    )
+                    select id from account_analytic_account_hierarchy
+                )
                 AND ap.id in (
                     SELECT id
                     from account_period


### PR DESCRIPTION
In the [previous PR](https://github.com/onesteinbv/addons-onestein/pull/84) where I overrode `_prac_amt`, I didn't take into account [another bugfix](https://github.com/odoo/odoo/pull/6910) proposed some time earlier, but rejected by Odoo.

The bugfix seems to me as valid and I don't see any way in which it can break anything, and for version 8.0 I also don't want to invest time in making fancy constructs with inherited functions to make both bugfixes play nicely together. Thus, I'm proposing that bugfix also as part of the override.