### PR TITLE
[12.0] connector_office_365 fix user access token copy

### DIFF
--- a/connector_office_365/models/res_users.py
+++ b/connector_office_365/models/res_users.py
@@ -30,9 +30,9 @@ class Office365Error(Exception):
 class ResUsers(models.Model):
     _inherit = 'res.users'
 
-    office_365_access_token = fields.Char()
-    office_365_refresh_token = fields.Char()
-    office_365_expiration = fields.Datetime()
+    office_365_access_token = fields.Char(copy=False)
+    office_365_refresh_token = fields.Char(copy=False)
+    office_365_expiration = fields.Datetime(copy=False)
 
     def __init__(self, pool, cr):
         super(ResUsers, self).__init__(pool, cr)


### PR DESCRIPTION
Fixing:
- When user A is duplicated, office 365 token is copied user B. User B communicates with Office 365 like if he is the user A. 

