### PR TITLE
[IMP] connector_office_hr_leave

### DIFF
--- a/connector_office_365/models/res_users.py
+++ b/connector_office_365/models/res_users.py
@@ -55,7 +55,7 @@ class ResUsers(models.Model):
         self.ensure_one()
 
         url = self.office_365_authorization_url(
-            [
+            [  # list of scopes
                 'User.Read',
                 'Calendars.ReadWrite',
                 'offline_access'
@@ -84,7 +84,11 @@ class ResUsers(models.Model):
         redirect_uri = config.get_param('web.base.url') + '/office-365-oauth/success'
 
         token = None
-        if self.office_365_access_token and self.office_365_expiration > fields.Datetime.now():
+        if (
+                self.office_365_access_token and
+                self.office_365_expiration and
+                self.office_365_expiration > fields.Datetime.now()
+        ):
             token = {
                 'access_token': self.office_365_access_token,
                 'refresh_token': self.office_365_refresh_token,

--- a/connector_office_365_hr_leave/models/__init__.py
+++ b/connector_office_365_hr_leave/models/__init__.py
@@ -1,2 +1,3 @@
 from . import calendar_event
 from . import hr_leave
+from . import res_users

--- a/connector_office_365_hr_leave/models/hr_leave.py
+++ b/connector_office_365_hr_leave/models/hr_leave.py
@@ -93,6 +93,6 @@ class HolidaysRequest(models.Model):
             ).action_refuse()
             # don't flood the user with activities
             if rec.user_id not in activity_scheduled:
-                self._office_365_activity_require_auth()
+                rec._office_365_activity_require_auth()
                 activity_scheduled.add(rec.user_id)
         return res

--- a/connector_office_365_hr_leave/models/hr_leave.py
+++ b/connector_office_365_hr_leave/models/hr_leave.py
@@ -72,7 +72,7 @@ class HolidaysRequest(models.Model):
         activity_scheduled = set()
         now = fields.Datetime.now()
         leaves_non_expired_tokens = self.filtered(
-            lambda r: r.meeting_id.user.office_365_access_token and
+            lambda r: r.meeting_id.user_id.office_365_access_token and
             r.meeting_id.office_365_expiration > now
         )
         leaves_expired_tokens = self - leaves_non_expired_tokens

--- a/connector_office_365_hr_leave/models/hr_leave.py
+++ b/connector_office_365_hr_leave/models/hr_leave.py
@@ -1,8 +1,11 @@
-# Copyright 2019 Camptocamp
+# Copyright 2019-2021 Camptocamp
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+import logging
 
-from odoo import api, fields, models, _
-from odoo.exceptions import UserError
+from odoo import api, fields, models
+from odoo.addons.connector_office_365 import Office365Error
+
+_logger = logging.getLogger(__name__)
 
 
 class HolidaysRequest(models.Model):
@@ -27,23 +30,34 @@ class HolidaysRequest(models.Model):
 
     def office_365_manual_push(self):
         self.ensure_one()
+        self.sudo().need_o365_manual_push = False
         self._office_365_push()
-        self.need_o365_manual_push = False
+
+    def _office_365_activity_require_auth(self):
+        # create activity to ask user to authenticate
+        xmlid = (
+            'connector_office_365_hr_leave.'
+            'mail_act_office_365_authenticate'
+        )
+        self.sudo().activity_schedule(xmlid, user_id=self.user_id.id)
 
     def _office_365_push(self):
         user = self.meeting_id.user_id
-        if user.office_365_access_token:
-            self.meeting_id.sudo(user).with_context(
-                origin_leave_id=self.id
-            ).office_365_push()
+        if user.office_365_access_token and user.office_365_expiration > fields.Datetime.now():
+            try:
+                self.meeting_id.sudo(user).with_context(
+                    origin_leave_id=self.id
+                ).office_365_push()
+            except Office365Error as exc:
+                _logger.warning(
+                    'Error pushing meeting %d of leave %d: %s',
+                    self.meeting_id.id, self.id, exc
+                )
+                self.sudo().need_o365_manual_push = True
         else:
-            self.need_o365_manual_push = True
-            # create activity to ask user to authenticate
-            xmlid = (
-                'connector_office_365_hr_leave.'
-                'mail_act_office_365_authenticate'
-            )
-            self.activity_schedule(xmlid, user_id=self.user_id.id)
+            self.sudo().need_o365_manual_push = True
+        if self.need_o365_manual_push:
+            self._office_365_activity_require_auth()
 
     def _validate_leave_request(self):
         super()._validate_leave_request()
@@ -54,7 +68,31 @@ class HolidaysRequest(models.Model):
 
     @api.multi
     def action_refuse(self):
-        return super(
-            HolidaysRequest,
-            self.with_context(o365_override_user=True)
-        ).action_refuse()
+        res = False
+        activity_scheduled = set()
+        now = fields.Datetime.now()
+        leaves_non_expired_tokens = self.filtered(
+            lambda r: r.meeting_id.user.office_365_access_token and
+            r.meeting_id.office_365_expiration > now
+        )
+        leaves_expired_tokens = self - leaves_non_expired_tokens
+        for rec in leaves_non_expired_tokens:
+            try:
+                res = super(
+                    HolidaysRequest,
+                    rec.with_context(o365_override_user=True)
+                ).action_refuse()
+            except Office365Error:
+                leaves_expired_tokens += rec
+        for rec in leaves_expired_tokens:
+            # don't delete event from office365, create an activity
+            # requesting the user to auth on office (at most 1 activity per user)
+            res = super(
+                HolidaysRequest,
+                rec.with_context(office_365_force=True)
+            ).action_refuse()
+            # don't flood the user with activities
+            if rec.user_id not in activity_scheduled:
+                self._office_365_activity_require_auth()
+                activity_scheduled.add(rec.user_id)
+        return res

--- a/connector_office_365_hr_leave/models/res_users.py
+++ b/connector_office_365_hr_leave/models/res_users.py
@@ -1,0 +1,47 @@
+# Copyright 2021 Camptocamp
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+import logging
+
+from odoo import api, models
+
+_logger = logging.getLogger(__name__)
+
+
+class ResUsers(models.Model):
+    _inherit = 'res.users'
+
+    @api.multi
+    def office_365_persist_token(self, token):
+        tok = super().office_365_persist_token(token)
+        self._async_office_365_push_events()
+        return tok
+
+    def _async_office_365_push_events(self):
+        self.ensure_one()
+        try:
+            leaves = self.env['hr.leave'].search(
+                [
+                    ('need_o365_manual_push', '=', True),
+                    ('user_id', '=', self.id),
+                ]
+            )
+            if leaves:
+                _logger.info('Pushing pending validated leaves to office365: %s', leaves)
+            for leave in leaves:
+                leave.office_365_manual_push()
+        except Exception:
+            _logger.exception('unable to push pending validated leaves')
+            # ignore for now, will be retried later
+        try:
+            # delete pending meetings from canceled leaves
+            leaves = self.env['hr.leave'].search(
+                [('state', 'in', ('draft', 'cancel')),
+                 ('meeting_id', '!=', False),
+                 ]
+            )
+            if leaves:
+                _logger.info('Removing calendar events of refused leaves from Office365', leaves)
+            leaves.with_context(o365_override_user=True).mapped('meeting_id').unlink()
+        except Exception:
+            _logger.exception('unable to remove refused leaves events')
+            # ignore for now, will be retried later


### PR DESCRIPTION
When a manager confirms a leave, sometimes the token has expired and
this can generate an error.

This PR changes the logic to check the expiration date of the token
before synchronizing to Office365 and in case the token is expired we
request a login. When the token is refreshed, the pending
synchronizations are performed.